### PR TITLE
Fix oslo policy file genrator tool for Magnum

### DIFF
--- a/magnum/common/policy.py
+++ b/magnum/common/policy.py
@@ -132,6 +132,14 @@ def add_policy_attributes(target):
     return target
 
 
+def get_enforcer():
+    # This method is used by oslopolicy CLI scripts in order to generate policy
+    # files from overrides on disk and defaults in code.
+    cfg.CONF([], project='magnum')
+    init()
+    return _ENFORCER
+
+
 def check_is_admin(context):
     """Whether or not user is admin according to policy setting.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,6 +47,9 @@ oslo.config.opts =
 oslo.config.opts.defaults =
     magnum = magnum.common.config:set_config_defaults
 
+oslo.policy.enforcer =
+    magnum = magnum.common.policy:get_enforcer
+
 oslo.policy.policies =
     magnum = magnum.common.policies:list_rules
 


### PR DESCRIPTION
oslo tool to generate the policy or sample policy file does not work for magnum service.

``oslopolicy-policy-generator --namespace magnum``  end up with below error:
    ModuleNotFoundError: No module named 'magnum.policy'

same error with oslopolicy-sample-generator --namespace magnum

oslo.policy policy generator tool look for the service oslo policy enforcer entry and does not find it. setup.cfg file is missing the entry point for magnum oslo policy enforcer.

- https://lists.openstack.org/archives/list/openstack-discuss@lists.openstack.org/thread/5ZRWWL3YKWX3XCFGTC4G2KP6PCJMBL64/

Closes-Bug: #2068519
Change-Id: Iff94f7dea491b0ea465b17cd60c37423224f9ffa (cherry picked from commit 8d09169a8aa4d8425e9ab7f37bbb636c4410a39f)